### PR TITLE
reconnect guarantee no data loss when using stateful server

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ Client connects the the server and sends a GRPC comms message `START [uuid] [n]`
 
 Once server receives `START [uuid] [n]` it will store this session id information on the server side and will start sending random `uint32` numbers. Once all numbers are sent server will close the stream.
 
-In case the connection drops, client can reconnect by sending `CONTINUE [uuid]` message. Note that the server saves session information for 30 seconds before discarding so if client doesn't reconnect after `30` seconds, the continue attempt will fail and server will respond with an error message.
+In case the connection drops, client can reconnect by sending `CONTINUE [uuid] [lastNumber]` message where `[lastNumber]` is the last number received by the server. Note that the server saves session information for 30 seconds before discarding so if client doesn't reconnect after `30` seconds, the continue attempt will fail and server will respond with an error message.
 
 When client reconnects server will send two integers before continuing with the normal stream:
 

--- a/src-client/main.js
+++ b/src-client/main.js
@@ -39,7 +39,15 @@ function main() {
     } else if (mode == "stateful-test") {
         client = new StatefulClient("a17417a0-aa39-40b5-8675-247713cc4908", 5);
     } else if (mode == "stateful-test-reconnect") {
-        client = new StatefulClient("a17417a0-aa39-40b5-8675-247713cc4908", 5, true);
+        if (args["_"].length !== 1) {
+            console.log(
+                `Please specify last number received`
+            );
+            process.exit();
+        }
+
+        var n = Math.round(args["_"][0]);
+        client = new StatefulClient("a17417a0-aa39-40b5-8675-247713cc4908", 5, true, n);
     } else {
         console.log(`Mode should be either "statefull" or "stateless"`)
         process.exit();

--- a/src-client/stateful_client.js
+++ b/src-client/stateful_client.js
@@ -2,13 +2,14 @@ var max_n = 0xfff
 var checksum_mod = 123456
 
 class StatefulClient {
-    constructor(id = undefined, n = undefined, cnt = false) {
+    constructor(id = undefined, n = undefined, cnt = false, lastNumber = 0) {
         this._n = n === undefined ? this.getN() : n;
         this._getId = id === undefined ? this.getId() : id;
         this._count = 0
         this._timeout = 10000;
         this._checksum = 0;
         this._cnt = cnt;
+        this._lastNumber = lastNumber;
 
         console.log(`N: ${this._n}`)
         console.log(`UUID: ${this._getId}`)
@@ -24,7 +25,7 @@ class StatefulClient {
             call.write({ message: `START "${this._getId}" ${this._n}` })
             // continue if we had data before
         } else if (this._cnt || lastMessage.data !== undefined) {
-            call.write({ message: `CONTINUE ${this._getId}` });
+            call.write({ message: `CONTINUE ${this._getId} ${this._lastNumber}` });
             this._cnt = false
             this._storeCount = true
         }
@@ -62,6 +63,7 @@ class StatefulClient {
             console.log(`Response: ${result.data.number} | Count: ${this._count}`)
         }
 
+        this._lastNumber = result.data.number
         this._checksum += Number(result.data.number) % checksum_mod
         this._checksum = this._checksum % checksum_mod
     }

--- a/src-server/store/store_interface.go
+++ b/src-server/store/store_interface.go
@@ -19,4 +19,6 @@ type Store interface {
 	GetNext(id uuid.UUID) uint32
 
 	Update(id uuid.UUID, next uint32)
+
+	SyncState(id uuid.UUID, lastNumber uint32) error
 }


### PR DESCRIPTION
Fixing issue when some messages can be lost if connection drops since GRPC SendMsg doesn't guarantee the delivery but stores the message in the streaming buffer.

Fixes #1